### PR TITLE
Use example domain name (RFC2606).

### DIFF
--- a/manual/de/03-Managing-pages.md
+++ b/manual/de/03-Managing-pages.md
@@ -314,8 +314,8 @@ Seitenstruktur markiert. Contao unterstützt folgende 6 Seitentypen:
 Contao unterstützt mehrere Webseiten innerhalb der Seitenstruktur und leitet
 Besucher je nach DNS- und Spracheinstellungen automatisch auf einen bestimmten
 Startpunkt einer Webseite weiter. Nehmen wir an, Sie betreiben eine
-zweisprachige Firmenwebseite unter "www.firma.de" und eine kleine private
-Webseite unter der Domain "www.private-seite.de". Sie benötigen dafür drei
+zweisprachige Firmenwebseite unter "www.example.com" und eine kleine private
+Webseite unter der Domain "www.personal.example.org". Sie benötigen dafür drei
 Startpunkte:
 
 <table>
@@ -355,22 +355,22 @@ Domain und seiner Browsersprache weitergeleitet wird.
   <th>Weiterleitung</th>
 </tr>
 <tr>
-  <td>www.firma.de</td>
+  <td>www.example.com</td>
   <td>Englisch</td>
   <td>Englische Firmenseite</td>
 </tr>
 <tr>
-  <td>www.firma.de</td>
+  <td>www.example.com</td>
   <td>Deutsch</td>
   <td>Deutsche Firmenseite</td>
 </tr>
 <tr>
-  <td>www.firma.de</td>
+  <td>www.example.com</td>
   <td>Spanisch</td>
   <td>Englische Firmenseite</td>
 </tr>
 <tr>
-  <td>www.private-seite.de</td>
+  <td>www.personal.example.org</td>
   <td>egal</td>
   <td>Persönliche Webseite</td>
 </tr>

--- a/manual/de/04-Managing-content.md
+++ b/manual/de/04-Managing-content.md
@@ -260,7 +260,7 @@ Jede Nachricht hat eine eindeutige URL (Permalink), die zur Referenzierung des
 Beitrags verwendet werden kann:
 
 ```
-http://www.domain.com/news/items/james-wilson-returns.html
+http://www.example.com/news/items/james-wilson-returns.html
 ```
 
 Die oben genannte URL fordert den Beitrag "james-wilson-returns" auf der Seite
@@ -329,7 +329,7 @@ Jeder Termin hat eine eindeutige URL (Permalink), die zur Referenzierung des
 Events verwendet werden kann:
 
 ```
-http://www.domain.com/event-reader/events/final-exams.html
+http://www.example.com/event-reader/events/final-exams.html
 ```
 
 Die oben genannte URL fordert den Event "final-exams" auf der Seite "events" an.
@@ -458,7 +458,7 @@ Jeder Newsletter hat eine eindeutige URL (Permalink), die zur Referenzierung der
 Nachricht verwendet werden kann:
 
 ```
-http://www.domain.com/newsletters/items/james-wilson-returns.html
+http://www.example.com/newsletters/items/james-wilson-returns.html
 ```
 
 Die obige URL fordert den Newsletter "james-wilson-returns" auf der Seite

--- a/manual/en/03-Managing-pages.md
+++ b/manual/en/03-Managing-pages.md
@@ -303,8 +303,8 @@ supports 6 different page types which are explained below.
 Contao supports multiple websites within the site structure and automatically
 redirects visitors to a particular website root page depending on its DNS and
 language settings. Let us assume that you are running a bilingual corporate
-website which uses the domain "www.company.com" and a small private website
-which uses the domain "www.personal-website.com". You need three website root
+website which uses the domain "www.example.com" and a small private website
+which uses the domain "www.personal.example.org". You need three website root
 pages for that:
 
 <table>
@@ -344,22 +344,22 @@ on the domain and his browser language.
   <th>Redirect target</th>
 </tr>
 <tr>
-  <td>www.company.com</td>
+  <td>www.example.com</td>
   <td>English</td>
   <td>English corporate website</td>
 </tr>
 <tr>
-  <td>www.company.com</td>
+  <td>www.example.com</td>
   <td>German</td>
   <td>German corporate website</td>
 </tr>
 <tr>
-  <td>www.company.com</td>
+  <td>www.example.com</td>
   <td>Spanish</td>
   <td>English corporate website</td>
 </tr>
 <tr>
-  <td>www.personal-website.com</td>
+  <td>www.personal.example.org</td>
   <td>irrelevant</td>
   <td>Personal website</td>
 </tr>

--- a/manual/en/04-Managing-content.md
+++ b/manual/en/04-Managing-content.md
@@ -257,7 +257,7 @@ extension includes 4 front end modules:
 Each news item has a unique URL (permalink) that can be used to reference it:
 
 ```
-http://www.domain.com/news/items/james-wilson-returns.html
+http://www.example.com/news/items/james-wilson-returns.html
 ```
 
 The above URL requests the news item "james-wilson-returns" via the page "news".
@@ -325,7 +325,7 @@ extension includes 4 front end modules:
 Each event has a unique URL (permalink) that can be used to reference it:
 
 ```
-http://www.domain.com/event-reader/events/final-exams.html
+http://www.example.com/event-reader/events/final-exams.html
 ```
 
 The above URL requests the event "final-exams" via the page "events". Remember
@@ -450,7 +450,7 @@ up on the website.
 Each newsletter has a unique URL (permalink) that can be used to reference it:
 
 ```
-http://www.domain.com/newsletters/items/james-wilson-returns.html
+http://www.example.com/newsletters/items/james-wilson-returns.html
 ```
 
 The above URL requests the newsletter "james-wilson-returns" via the page


### PR DESCRIPTION
Use reserved domain names (RFC2606).

I tried to fix English version only since I do not know such example domain names exists in ".de" domain.  (There are example domain names in "jp" domain.)
