### PR TITLE
correct Typo

### DIFF
--- a/cookbook/de/Models.md
+++ b/cookbook/de/Models.md
@@ -87,7 +87,7 @@ Die Methode akzeptiert ein Array mit folgenden Werten:
 		<th>Schlüssel</th>
 		<th>Typ</th>
 		<th>Beschreibung</th>
-	<tr>
+	</tr>
 	<tr>
 		<td>column</td>
 		<td>mixed</td>


### PR DESCRIPTION
added missing / in closing tr that caused problems when converting from markdown to LaTeX
