### PR TITLE
Remove "urlencode" and "rawurlencode" from version 3.2 in French

### DIFF
--- a/manual/fr/04-Managing-content.md
+++ b/manual/fr/04-Managing-content.md
@@ -1510,18 +1510,6 @@ Drapeaux disponibles :
     <td><a target="_blank" href="http://php.net/base64_decode">Fonction PHP
     </a></td>
 </tr>
-<tr>
-    <td><code>urlencode</code></td>
-    <td>Encode une chaîne en URL.</td>
-    <td><a target="_blank" 
-    href="http://php.net/urlencode">Fonction PHP</a></td>
-</tr>
-<tr>
-    <td><code>rawurlencode</code></td>
-    <td>Encode une chaîne en URL, selon la RFC 3986.</td>
-    <td><a target="_blank" 
-    href="http://php.net/rawurlencode">Fonction PHP</a></td>
-</tr>
 </table>
 
 


### PR DESCRIPTION
Removed in version 3.2 only.
