### PR TITLE
add showColumns flag to table.list.label

### DIFF
--- a/manual/de/06-data-container-arrays/referenz.md
+++ b/manual/de/06-data-container-arrays/referenz.md
@@ -280,6 +280,11 @@ und eigene Bezeichnungen einfügen.
       <code>array('title', 'user_id:tl_user.name')</code>).</td>
 </tr>
 <tr>
+  <td>showColumns</td>
+  <td>wahr/falsch (<code>boolean</code>)</td>
+  <td>Legt fest, ob Contao einen Tabellenkopf mit Spaltennamen ausgeben soll.</td>
+</tr>
+<tr>
   <td>format</td>
   <td>Format-String (<code>string</code>)</td>
   <td>HTML-Zeichenkette zur Formatierung der angezeigten Felder (z.B.

--- a/manual/de/06-data-container-arrays/referenz.md
+++ b/manual/de/06-data-container-arrays/referenz.md
@@ -281,8 +281,8 @@ und eigene Bezeichnungen einfügen.
 </tr>
 <tr>
   <td>showColumns</td>
-  <td>wahr/falsch (<code>boolean</code>)</td>
-  <td>Legt fest, ob Contao einen Tabellenkopf mit Spaltennamen ausgeben soll.</td>
+  <td>true/false (<code>boolean</code>)</td>
+  <td>Legt fest, ob Contao einen Tabellenkopf mit Spaltennamen ausgeben soll (vgl. Mitgliederliste im Backend)</td>
 </tr>
 <tr>
   <td>format</td>

--- a/manual/en/06-data-container-arrays/reference.md
+++ b/manual/en/06-data-container-arrays/reference.md
@@ -276,6 +276,11 @@ order and you can add custom labels.
       <code>array('title', 'user_id:tl_user.name')</code>).</td>
 </tr>
 <tr>
+  <td>showColumns</td>
+  <td>true/false (<code>boolean</code>)</td>
+  <td>If true Contao will generate a table header with column names</td>
+</tr>
+<tr>
   <td>format</td>
   <td>Format string (<code>string</code>)</td>
   <td>HTML string used to format the fields that will be shown (e.g.

--- a/manual/en/06-data-container-arrays/reference.md
+++ b/manual/en/06-data-container-arrays/reference.md
@@ -278,7 +278,7 @@ order and you can add custom labels.
 <tr>
   <td>showColumns</td>
   <td>true/false (<code>boolean</code>)</td>
-  <td>If true Contao will generate a table header with column names</td>
+  <td>If true Contao will generate a table header with column names (eg. backend member list)</td>
 </tr>
 <tr>
   <td>format</td>


### PR DESCRIPTION
The showColumns flag was missing in the documentation. If set, it will output a table header with column names like in the core tl_member. Thanks to a recent post by the_scrat in the community board :)

I can't provide a french translation. Maybe somebody else can?
