### PR TITLE
Update getArticle.md

### DIFF
--- a/api/hooks/getArticle.md
+++ b/api/hooks/getArticle.md
@@ -26,7 +26,7 @@ public function myGetArticle(Database_Result $objRow)
 	if ($objRow->grid == '4')
 	{
 		$arrCSS = deserialize($objRow->cssID, true);
-		$arrCSS[1] = trim($arrCSS[1] . ' grid4');
+		$arrCSS[1] = trim($arrCSS[1]) . ' grid4';
 		$objRow->cssID = serialize($arrCSS);
 	}
 }


### PR DESCRIPTION
changed the parameter of trim() because ' grid4' needs no (right) trim and $arrCSS[1] would not be right trimmed
