### PR TITLE
fix postLogin and postLogout hooks

### DIFF
--- a/api/extensions/hooks/postLogin.md
+++ b/api/extensions/hooks/postLogin.md
@@ -1,16 +1,17 @@
 # postLogin
 
-The `postLogin` hook is triggered after a user has logged into the front end. It
-passes the user object as argument and does not expect a return value.
+The `postLogin` hook is triggered after a user has logged in. This can 
+be either in the back end or the fornt end. It passes the user object 
+as argument and does not expect a return value.
 
 > **Tag** Available from version 2.4.3.
 
 
 ## Parameters
 
-1. *FrontendUser* `$objUser`
+1. *User* `$user`
 
-    The front end user (object) which has been logged in.
+    The back end or front end user (object) which has been logged in.
 
 
 ## Example
@@ -22,9 +23,11 @@ passes the user object as argument and does not expect a return value.
 $GLOBALS['TL_HOOKS']['postLogin'][] = array('MyClass', 'myPostLogin');
 
 // MyClass.php
-public function myPostLogin(FrontendUser $objUser)
+public function myPostLogin(User $user)
 {
-    // Do something
+    if (TL_MODE == 'FE') {
+     // Do something with the for front end user $user  
+    }
 }
 ```
 

--- a/api/extensions/hooks/postLogin.md
+++ b/api/extensions/hooks/postLogin.md
@@ -25,7 +25,7 @@ $GLOBALS['TL_HOOKS']['postLogin'][] = array('MyClass', 'myPostLogin');
 // MyClass.php
 public function myPostLogin(User $user)
 {
-    if (TL_MODE == 'FE') {
+    if ($user instanceof FrontendUser) {
      // Do something with the for front end user $user  
     }
 }

--- a/api/extensions/hooks/postLogin.md
+++ b/api/extensions/hooks/postLogin.md
@@ -1,7 +1,7 @@
 # postLogin
 
 The `postLogin` hook is triggered after a user has logged in. This can 
-be either in the back end or the fornt end. It passes the user object 
+be either in the back end or the front end. It passes the user object 
 as argument and does not expect a return value.
 
 > **Tag** Available from version 2.4.3.
@@ -26,7 +26,7 @@ $GLOBALS['TL_HOOKS']['postLogin'][] = array('MyClass', 'myPostLogin');
 public function myPostLogin(User $user)
 {
     if ($user instanceof FrontendUser) {
-     // Do something with the for front end user $user  
+        // Do something with the front end user $user  
     }
 }
 ```

--- a/api/extensions/hooks/postLogout.md
+++ b/api/extensions/hooks/postLogout.md
@@ -24,7 +24,7 @@ $GLOBALS['TL_HOOKS']['postLogout'][] = array('MyClass', 'myPostLogout');
 // MyClass.php
 public function myPostLogout(User $user)
 {
-    if (TL_MODE == 'FE') {
+    if ($user instanceof FrontendUser) {
      // Do something with the for front end user $user   
     }
 }

--- a/api/extensions/hooks/postLogout.md
+++ b/api/extensions/hooks/postLogout.md
@@ -1,16 +1,16 @@
 # postLogout
 
-The `postLogout` hook is triggered after a user has logged out from the front
-end. It passes the user object as argument and does not expect a return value.
+The `postLogout` hook is triggered after a user has logged out from the back end 
+or front end. It passes the user object as argument and does not expect a return value.
 
 > **Tag** Available from version 2.4.3.
 
 
 ## Parameters
 
-1. *FrontendUser* `$objUser`
+1. *User* `$user`
 
-    The front end user (object) which has been logged out.
+    The back end or front end user (object) which has been logged out.
 
 
 ## Example
@@ -22,9 +22,11 @@ end. It passes the user object as argument and does not expect a return value.
 $GLOBALS['TL_HOOKS']['postLogout'][] = array('MyClass', 'myPostLogout');
 
 // MyClass.php
-public function myPostLogout(FrontendUser $objUser)
+public function myPostLogout(User $user)
 {
-    // Do something
+    if (TL_MODE == 'FE') {
+     // Do something with the for front end user $user   
+    }
 }
 ```
 

--- a/api/extensions/hooks/postLogout.md
+++ b/api/extensions/hooks/postLogout.md
@@ -25,7 +25,7 @@ $GLOBALS['TL_HOOKS']['postLogout'][] = array('MyClass', 'myPostLogout');
 public function myPostLogout(User $user)
 {
     if ($user instanceof FrontendUser) {
-     // Do something with the for front end user $user   
+        // Do something with the front end user $user   
     }
 }
 ```


### PR DESCRIPTION
both hooks apply to backend and front end users as they are triggered in the  `User` class that both `FrontendUser`and `BackendUser` are derived from.
