### PR TITLE
Highlight the links in the infobox "alert-info".

### DIFF
--- a/manual/de/styles/website.css
+++ b/manual/de/styles/website.css
@@ -17,6 +17,10 @@ blockquote.alert-info {
     border-color: #4b85ba !important;
 }
 
+blockquote.alert-info p a {
+    text-decoration: underline !important;
+}
+
 blockquote.alert-success {
     background-color: #f3f8ee !important;
     color: #77ac45 !important;

--- a/manual/en/styles/website.css
+++ b/manual/en/styles/website.css
@@ -17,6 +17,10 @@ blockquote.alert-info {
     border-color: #4b85ba !important;
 }
 
+blockquote.alert-info p a {
+    text-decoration: underline !important;
+}
+
 blockquote.alert-success {
     background-color: #f3f8ee !important;
     color: #77ac45 !important;

--- a/manual/fr/styles/website.css
+++ b/manual/fr/styles/website.css
@@ -17,6 +17,10 @@ blockquote.alert-info {
     border-color: #4b85ba !important;
 }
 
+blockquote.alert-info p a {
+    text-decoration: underline !important;
+}
+
 blockquote.alert-success {
     background-color: #f3f8ee !important;
     color: #77ac45 !important;


### PR DESCRIPTION
Links have the same color as the text in the infobox "alert-info". I have added an underline to differentiate them.

![capture d ecran 2015-11-23 a 16 11 55](https://cloud.githubusercontent.com/assets/814476/11340665/3f421596-91ff-11e5-98a9-96ad92ae0978.png)
