### PR TITLE
remove some wording regarding the contao check

### DIFF
--- a/manual/de/01-installation/den-live-server-konfigurieren.md
+++ b/manual/de/01-installation/den-live-server-konfigurieren.md
@@ -36,10 +36,7 @@ Firefox (ab Version 2) oder Internet Explorer (ab Version 8) getestet.
 ### Der Contao-Check
 
 Laden Sie den Contao-Check herunter und finden Sie heraus, ob Ihr Server die
-Contao-Systemvoraussetzungen erfüllt. Der Contao-Check prüft, ob Sie das
-Extension Repository und das Live Update nutzen können. Je nach 
-Systemkonfiguration können Sie mit Hilfe des Web-Installers eine neue 
-Contao-Installation aufsetzen oder eine bestehende Installation prüfen.
+Contao-Systemvoraussetzungen erfüllt.
 
 ![](images/contao-check.jpg)
 
@@ -47,6 +44,9 @@ Entpacken Sie die Zip-Datei, übertragen Sie den Ordner
 `check` in Ihr Contao-Verzeichnis und öffnen Sie ihn in einem Browser.
 
 [Den Contao-Check herunterladen][1] | [Zum Projekt auf GitHub][2]
+
+> **Note** Eine Contao 4 Installation kann mit dem Contao Check nicht validiert 
+werden.
 
 
 ### Provider-spezifische Einstellungen

--- a/manual/en/01-installation/configuring-the-live-server.md
+++ b/manual/en/01-installation/configuring-the-live-server.md
@@ -35,10 +35,7 @@ Contao has been tested successfully with all major browsers like Firefox
 ### The Contao check
 
 Download the Contao Check to find out whether your server meets the Contao
-system requirements. The script will check whether you can use the Extension
-Repository and the Live Update. Depending on your system configuration, you
-can set up a new Contao installation with the web installer or validate an
-existing installation.
+system requirements.
 
 ![](images/contao-check.jpg)
 
@@ -46,6 +43,8 @@ Extract the Zip file, upload the `check` folder to your Contao installation
 directory and open it in a web browser.
 
 [Download the Contao Check][1] | [Open the GitHub project][2]
+
+> **Note** You cannot validate a Contao 4 installation with the Contao Check.
 
 
 ### ISP-specific settings

--- a/manual/fr/01-installation/configuration-du-serveur-en-ligne.md
+++ b/manual/fr/01-installation/configuration-du-serveur-en-ligne.md
@@ -48,6 +48,8 @@ d'installation de Contao et ouvrez-le dans un navigateur Web.
 
 [Télécharger Contao Check][1] | [Ouvrir le projet sur GitHub][2]
 
+> **Note** Vous ne pouvez pas valider une installation de Contao 4 avec Contao Check.
+
 
 ### Paramètres FAI spécifiques
 

--- a/manual/fr/01-installation/configuration-du-serveur-en-ligne.md
+++ b/manual/fr/01-installation/configuration-du-serveur-en-ligne.md
@@ -39,10 +39,7 @@ Contao a été testé avec succès avec tous les principaux navigateurs comme Fi
 ### Contao Check
 
 Télécharger "Contao Check" afin de savoir si votre serveur répond aux exigences
-du système de Contao. Le script va vérifier si vous pouvez utiliser le
-référentiel d'extensions ainsi que le "Live Update". Selon la configuration de
-votre système, vous pouvez mettre en place une nouvelle installation de Contao
-avec l'installateur web ou valider une installation existante.
+du système de Contao.
 
 ![](images/contao-check.jpg)
 


### PR DESCRIPTION
I have removed

> The script will check whether you can use the Extension Repository and the Live Update. Depending on your system configuration, you can set up a new Contao installation with the web installer or validate an existing installation.

since none of that applies to Contao 4. Also I have added a note, that you cannot validate a Contao 4 installation (since you can still see the button in the screenshot).
