### PR TITLE
fix description for extnd regex

### DIFF
--- a/api/dca/reference.md
+++ b/api/dca/reference.md
@@ -649,7 +649,7 @@ Each field can be validated against a regular expression.
         </tr>
         <tr>
           <td><b>extnd</b></td>
-          <td>disallows <code>#&amp;()/&lt;=&gt;</code></td>
+          <td>disallows <code>#&lt;&gt;()\=</code></td>
         </tr>
         <tr>
           <td><b>folderalias</b></td>


### PR DESCRIPTION
1. `extnd` does not actually disallow `&`
2. `extnd` actually disallows `\`, not `/`
3. the order of the symbols is now equal to [Validator::isExtendedAlphanumeric](https://github.com/contao/core/blob/3.5.18/system/modules/core/library/Contao/Validator.php#L95-L105)

See https://github.com/contao/core/issues/8556

This should be merged into the older docs as well (including Contao `2.11`).