### PR TITLE
include information about the start page alias

### DIFF
--- a/manual/de/03-seiten-verwalten/seitentypen.md
+++ b/manual/de/03-seiten-verwalten/seitentypen.md
@@ -48,6 +48,18 @@ Seitenstruktur markiert. Contao unterstützt folgende 6 Seitentypen:
 </table>
 
 
+### Startseite
+
+Wenn das Frontend mit einer leeren Request URL geöffnet wird (z.B. 
+`http://www.example.org/`), zeigt Contao die erste veröffentlichte Seite im
+jeweiligen Startpunkt. Der Alias dieser Seite sollte auf `index` gesetzt werden.
+Nur dann wird die erzeugte URL für diese Seite auch ein leerer Request sein.
+
+Ab Version `3.5.18` wird außerdem automatisch auf die Startseite weitergeleitet,
+falls deren Alias nicht `index` lautet. Die URL inkludiert dann den Alias und das
+global definierte Suffix (z.B. `http://www.example.org/home.html`).
+
+
 ### Multidomain-Betrieb
 
 Contao unterstützt mehrere Webseiten innerhalb der Seitenstruktur und leitet

--- a/manual/en/03-managing-pages/page-types.md
+++ b/manual/en/03-managing-pages/page-types.md
@@ -48,6 +48,18 @@ supports 6 different page types which are explained below.
 </table>
 
 
+### Start page
+
+When the front end is opened with an empty request URL (e.g.
+`http://www.example.org/`), Contao will show  the first published page within
+the respective website root. You should set the alias of this page to `index`.
+Only then will the generated URL to that page also be an empty request.
+
+As of version `3.5.18`, Contao will also automatically redirect to the start 
+page using its alias and the globally defined suffix (e.g. 
+`http://www.example.org/home.html`), if the alias is not `index`.
+
+
 ### Multi-domain mode
 
 Contao supports multiple websites within the site structure and automatically

--- a/manual/en/03-managing-pages/page-types.md
+++ b/manual/en/03-managing-pages/page-types.md
@@ -51,7 +51,7 @@ supports 6 different page types which are explained below.
 ### Start page
 
 When the front end is opened with an empty request URL (e.g.
-`http://www.example.org/`), Contao will show  the first published page within
+`http://www.example.org/`), Contao will show the first published page within
 the respective website root. You should set the alias of this page to `index`.
 Only then will the generated URL to that page also be an empty request.
 

--- a/manual/fr/03-gestion-des-pages/types-de-page.md
+++ b/manual/fr/03-gestion-des-pages/types-de-page.md
@@ -58,7 +58,7 @@ de cette page. C'est seulement alors que l'URL généré pour cette page sera
 également une requête vide.
 
 À partir de la version `3.5.18`, Contao redirigera automatiquement vers la page
-d'accueil même si l'alias n'est pas défini comme `index`. L'URL comprend alors
+d'accueil si l'alias n'est pas défini comme `index`. L'URL comprend alors
 l'alias et le suffixe défini globalement (par ex.
 `http://www.example.org/home.html`).
 

--- a/manual/fr/03-gestion-des-pages/types-de-page.md
+++ b/manual/fr/03-gestion-des-pages/types-de-page.md
@@ -49,6 +49,20 @@ expliqués ci-dessous.
 </table>
 
 
+### Page d'accueil
+
+Lorsque le front office est ouvert avec une requête d'URL vide (par ex.
+`http://www.example.org/`), Contao affichera la première page publiée dans
+la racine du site internet respectif. Vous devez définir `index` comme alias
+de cette page. C'est seulement alors que l'URL généré pour cette page sera
+également une requête vide.
+
+À partir de la version `3.5.18`, Contao redirigera automatiquement vers la page
+d'accueil même si l'alias n'est pas défini comme `index`. L'URL comprend alors
+l'alias et le suffixe défini globalement (par ex.
+`http://www.example.org/home.html`).
+
+
 ### Mode multi-domaines
 
 Contao supporte plusieurs sites internet à l'intérieur de la structure de site 


### PR DESCRIPTION
I have added a section explaining the mechanic with the `index` alias of the start page. It's a feature that has never been documented and many users still do not know about this.

Any comments on the wording?